### PR TITLE
Update plugin name and add uninstall functionality

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-*** Test Add to Dom Plugin Changelog ***
+*** Polymuse-Woocommerce Changelog ***
 
 2025-01-19 - version 0.0.0
 * Project setup

--- a/polymuse-woocommerce.php
+++ b/polymuse-woocommerce.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: PolyMuse
+Plugin Name: polymuse-woocommerce
 Plugin URI: https://yourwebsite.com/
 Description: Allows users to add 3D models to WooCommerce products
 Version: 1.0

--- a/polymuse.php
+++ b/polymuse.php
@@ -117,7 +117,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
 
         return $html;
     }
-    add_filter('woocommerce_single_product_image_thumbnail_html', 'polymuse_add_model_to_gallery', 10, 4);
+    add_filter('woocommerce_single_product_image_thumbnail_html', 'polymuse_add_model_and_thumbnail_to_gallery', 10, 4);
 
     function add_buttons_container()
     {

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: PolyMuse
+Plugin Name: polymuse-woocommerce
 */
 
 if (!defined('WP_UNINSTALL_PLUGIN')) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,4 +8,4 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 }
 
 // Remove post meta data
-delete_post_meta_by_key('_3d_model_url');
+// delete_post_meta_by_key('_3d_model_url');

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,4 +1,8 @@
 <?php
+/*
+Plugin Name: PolyMuse
+*/
+
 if (!defined('WP_UNINSTALL_PLUGIN')) {
     exit;
 }
@@ -11,4 +15,33 @@ $posts = get_posts(array(
 
 foreach ($posts as $post) {
     delete_post_meta($post->ID, '_3d_model_url');
+}
+
+// Remove options
+delete_option('polymuse_options');
+
+// Remove custom transients
+delete_transient('polymuse_transient');
+
+// Remove custom user meta
+delete_metadata('user', 0, 'polymuse_user_meta', '', true);
+
+// Remove custom cron jobs
+wp_clear_scheduled_hook('polymuse_cron_job');
+
+// Remove custom files (not necessary in this case, but good practice)
+$upload_dir = wp_upload_dir();
+$polymuse_files = array(
+    '3d-model-thumbnail.png',
+    '3d.webp',
+    'polymuse.js',
+    'polymuse.php',
+    'styles.css',
+);
+
+foreach ($polymuse_files as $file) {
+    $file_path = $upload_dir['basedir'] . '/' . $file;
+    if (file_exists($file_path)) {
+        wp_delete_file($file_path);
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,4 +8,4 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 }
 
 // Remove post meta data
-// delete_post_meta_by_key('_3d_model_url');
+delete_post_meta_by_key('_3d_model_url');

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,40 +8,4 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 }
 
 // Remove post meta data
-$posts = get_posts(array(
-    'post_type' => 'product',
-    'posts_per_page' => -1,
-));
-
-foreach ($posts as $post) {
-    delete_post_meta($post->ID, '_3d_model_url');
-}
-
-// Remove options
-delete_option('polymuse_options');
-
-// Remove custom transients
-delete_transient('polymuse_transient');
-
-// Remove custom user meta
-delete_metadata('user', 0, 'polymuse_user_meta', '', true);
-
-// Remove custom cron jobs
-wp_clear_scheduled_hook('polymuse_cron_job');
-
-// Remove custom files (not necessary in this case, but good practice)
-$upload_dir = wp_upload_dir();
-$polymuse_files = array(
-    '3d-model-thumbnail.png',
-    '3d.webp',
-    'polymuse.js',
-    'polymuse.php',
-    'styles.css',
-);
-
-foreach ($polymuse_files as $file) {
-    $file_path = $upload_dir['basedir'] . '/' . $file;
-    if (file_exists($file_path)) {
-        wp_delete_file($file_path);
-    }
-}
+delete_post_meta_by_key('_3d_model_url');

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,14 @@
+<?php
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+// Remove post meta data
+$posts = get_posts(array(
+    'post_type' => 'product',
+    'posts_per_page' => -1,
+));
+
+foreach ($posts as $post) {
+    delete_post_meta($post->ID, '_3d_model_url');
+}


### PR DESCRIPTION
Change the plugin name to `polymuse-woocommerce` and implement an uninstall feature to remove specific post meta data. Additionally, fix a typo and update the filter function for better functionality.